### PR TITLE
EsLint: Report errors in files not touched in the PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,9 @@ jobs:
         uses: ataylorme/eslint-annotate-action@v2
         with:
           report-json: eslint_report.json
+          # Also report errors in files not changed in the PR,
+          # assuring there are no errors in the whole codebase
+          only-pr-files: false
 
   lint-ts:
     name: 'Lint TS'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Annotate
         if: steps.lint.outputs.generated-eslint-report == 'true'
-        uses: ataylorme/eslint-annotate-action@v2
+        uses: ataylorme/eslint-annotate-action@v3
         with:
           report-json: eslint_report.json
           # Also report errors in files not changed in the PR,


### PR DESCRIPTION
# Why?

- Expected to work like that in the first place.
- Keeps project clean.
