### PR TITLE
Jira workflow

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -1,0 +1,51 @@
+name: Jira integration
+
+on:
+  workflow_call:
+
+jobs:
+  jira:
+    name: 'Move jira issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify workflow setup
+        run: |
+          exit_code=0
+
+          if [ -z "${{ vars.JIRA_DOMAIN }}" ]
+          then
+            echo "::error::Missing var JIRA_DOMAIN. Set it to the origin you are accessing jira on, e.g. https://example.atlassian.net. It’s a good idea to set it on organisation level."
+            exit_code=78
+          fi
+
+          if [ -z "${{ secrets.JIRA_USER }}" ]
+          then
+            echo "::error::Missing secret JIRA_USER. E-mail address of user to run this automation as. It’s a good idea to set it on organisation level."
+            exit_code=78
+          fi
+
+          if [ -z "${{ secrets.JIRA_API_TOKEN }}" ]
+          then
+            echo "::error::Missing secret JIRA_API_TOKEN. Generate one at https://id.atlassian.com/manage-profile/security/api-tokens . It’s a good idea to set it on organisation level."
+            exit_code=78
+          fi
+
+          if [ -z "${{ vars.JIRA_STATUS_PR_DRAFT}}${{ vars.JIRA_STATUS_PR_READY }}${{ vars.JIRA_STATUS_PR_MERGED }}" ]
+          then
+            echo "::error::Missing var JIRA_STATUS_PR_DRAFT, JIRA_STATUS_PR_READY or JIRA_STATUS_PR_MERGED. Set any of them to the status names you want to transition issues to when PRs are in draft, ready or merged state. It’s a good idea to set them on organisation level."
+            exit_code=78
+          fi
+
+          exit $exit_code
+
+      - name: 'Move jira issues'
+        uses: verkstedt/jira-integration-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Hint: Set these on an organisation level and override in repos only when necessary
+          jira-domain: ${{ vars.JIRA_DOMAIN }}
+          jira-user: ${{ secrets.JIRA_USER }}
+          jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
+          jira-status-pr-draft: ${{ vars.JIRA_STATUS_PR_DRAFT }}
+          jira-status-pr-ready: ${{ vars.JIRA_STATUS_PR_READY }}
+          jira-status-pr-merged: ${{ vars.JIRA_STATUS_PR_MERGED }}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
    `.github/workflows/` in your repository.
 
    - skip `chromatic`, if your project doesn’t use it
-   - skip `trello`, if your project doesn’t use it 😿
+   - skip `jira`, if your project doesn’t use it
 
 2. When workflows run, they will most probably fail, because some
    secrets and/or vars are missing, but error messages should guide you
@@ -45,7 +45,8 @@
    want to overwrite them with project–specific values:
 
    - `SLACK_CHANNEL_ID` var, if you have a project–specific channel
-   - `TRELLO_ORG_NAME` var, if your project is not in default workspace
+   - `JIRA_STATUS_*` vars, if your project uses custom status names. You
+     can also set var to empty string to disable that transition.
 
 4. If “CI” workflow didn’t detect something you’d want it to run,
    customise it (see comments in the file).
@@ -132,15 +133,15 @@ Runs only on `main` branch and published PRs.
 Requires some vars and/or secrets.
 See [./.github/workflows/chromatic.yaml][workflow-chromatic] for details.
 
-### Trello
+### Jira
 
 Template:
-<https://github.com/verkstedt/.github/tree/main/workflow-templates/trello.yaml>
+<https://github.com/verkstedt/.github/tree/main/workflow-templates/jira.yaml>
 
-Moves [Trello] cards when PRs are created, published or merged.
+Moves [Jira] issues when PRs are created, published or merged.
 
 Requires some vars and/or secrets.
-See [./.github/workflows/trello.yaml][workflow-trello] for details.
+See [./.github/workflows/jira.yaml][workflow-jira] for details.
 
 ### Ref Comment in Commit
 
@@ -215,7 +216,7 @@ You have two options:
 
 [storybook]: https://storybook.js.org/docs/get-started/install
 [chromatic]: https://www.chromatic.com/start
-[trello]: https://trello.com
+[jira]: https://www.atlassian.com/software/jira
 [workflow-chromatic]: ./.github/workflows/chromatic.yaml
-[workflow-trello]: ./.github/workflows/trello.yaml
+[workflow-jira]: ./.github/workflows/jira.yaml
 [workflow-templates]: https://github.com/verkstedt/.github/tree/main/workflow-templates


### PR DESCRIPTION
- ⛔ Blocked by https://github.com/verkstedt/jira-integration-action/pull/4 (changes input names to use “status” instead of “list”)
- 🍷 Pairs with https://github.com/verkstedt/.github/pull/3

# Why?

Closes https://verkstedt.atlassian.net/browse/VIP-3

# What?

Introduces workflow similar to “trello”, but for “jira”. After our project migrate to “jira”, we can remove “trello” from the repository. [`trello-integration-action`](https://github.com/verkstedt/trello-integration-action) is already archived.
