### PR TITLE
Option to use different token for GitHub npm registry in npm install

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
 
       - name: Build StoryBook

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ on:
       build_env:
         description: '(DEPRECATED! Use env_vars instead) Environment variables to set when running build script.'
         required: false
+      GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN:
+        description: 'GitHub personal access token for npm registry authentication. You can create one at https://github.com/settings/tokens/new (scopes: `read:packages`, `repo` and `read:org`). If not set, will use secrets.GITHUB_TOKEN, which is enough for most cases.'
+        required: false
 
 env:
   NEXT_TELEMETRY_DISABLED: 1
@@ -42,6 +45,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
   lint-js:
     name: 'Lint JS'
@@ -60,6 +64,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       # Once https://github.com/actions/setup-node/issues/96 is
       # implemented, next two steps can be replaced with just:
@@ -106,6 +111,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint TS
         working-directory: ${{ inputs.working-directory }}
@@ -128,6 +134,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint CSS
         working-directory: ${{ inputs.working-directory }}
@@ -151,6 +158,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint Translations
         working-directory: ${{ inputs.working-directory }}
@@ -177,6 +185,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint fallback
         working-directory: ${{ inputs.working-directory }}
@@ -207,6 +216,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Test units
         working-directory: ${{ inputs.working-directory }}
@@ -237,6 +247,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Test end to end
         working-directory: ${{ inputs.working-directory }}
@@ -270,6 +281,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Test fallback
         working-directory: ${{ inputs.working-directory }}
@@ -313,6 +325,7 @@ jobs:
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Calculate cache key parts
         id: cache-keys

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: 'Directory in which to run things in.'
     required: false
     default: '.'
+  github-npm-registry-personal-access-token:
+    description: 'GitHub personal access token for npm registry authentication. You can create one at https://github.com/settings/tokens/new (scopes: `read:packages`, `repo` and `read:org`). If not set, will use secrets.GITHUB_TOKEN, which is enough for most cases.'
+    required: false
+    default: ''
 
 outputs:
   scripts:
@@ -73,11 +77,25 @@ runs:
           npm--${{ steps.cache-keys.outputs.os }}--${{ steps.cache-keys.outputs.node }}--${{ steps.cache-keys.outputs.packageJson }}--
           npm--${{ steps.cache-keys.outputs.os }}--${{ steps.cache-keys.outputs.node }}--
 
+    - name: Set up GitHub npm registry authentication
+      if: inputs.github-npm-registry-personal-access-token
+      shell: bash
+      run: |
+        echo "//npm.pkg.github.com/:_authToken=${{ inputs.github-npm-registry-personal-access-token }}" >> ~/.npmrc
+
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: ${{ inputs.working-directory }}
       shell: bash
+      env:
+        GITHUB_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN: ${{ inputs.github-npm-registry-personal-access-token }}
       run: |
+        if [ -n "$GITHUB_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN" ]
+        then
+          # GH_REGISTRY_TOKEN is commonly used in .npmrc and .yarnrc files
+          export GH_REGISTRY_TOKEN="$GITHUB_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN"
+        fi
+
         if [ -e "yarn.lock" ]
         then
           yarn install --immutable


### PR DESCRIPTION
# Why?

Installing a package from GitHub npm registry from a different organisation than the repository an action runs in requires passing a personal access token.

# How?

Setting `GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN` secret will use that token instead of `secrets.GITHUB_TOKEN` (using `GH_` prefix, because `GITHUB_` is reserved for GitHub).

We do that two–fold:

- set it in user’s `~/.npmrc`
- but also set `GH_REGISTRY_TOKEN` env var, in case `.npmrc` or `.yarnrc` in the repository references that variable.

This should have no effect on any repos that do not set `GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN` secret.