### PR TITLE
Change “latest” docker image tags

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -3,12 +3,12 @@ on:
   workflow_call:
     inputs:
       version:
-        description: "Version number (e.g., 1.0.0). If empty, will auto-increment patch version."
+        description: 'Version number (e.g., 1.0.0). If empty, will auto-increment patch version.'
         required: false
         type: string
     outputs:
       version:
-        description: "The version that was released"
+        description: 'The version that was released'
         value: ${{ jobs.release.outputs.version }}
 
 jobs:
@@ -48,11 +48,11 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo
               });
-            
+
               // Remove 'v' prefix if present
               const currentVersion = latestRelease.tag_name.replace('v', '');
               const [major, minor, patch] = currentVersion.split('.').map(Number);
-            
+
               // Increment patch version
               const nextVersion = `${major}.${minor + 1}.0`;
               core.setOutput('version', nextVersion);

--- a/.github/workflows/reusable-tag-docker-release-images.yml
+++ b/.github/workflows/reusable-tag-docker-release-images.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       release_id:
-        description: "The ID of the release"
+        description: 'The ID of the release'
         required: true
         type: string
 
@@ -94,7 +94,6 @@ jobs:
           done
     outputs:
       version_tags: ${{ steps.release_details.outputs.version_tags }}
-
 
   push_gar:
     needs: docker-tag

--- a/.github/workflows/reusable-tag-docker-release-images.yml
+++ b/.github/workflows/reusable-tag-docker-release-images.yml
@@ -61,16 +61,20 @@ jobs:
             core.setOutput('source_tag', shortSha);
 
             // Extract version without 'v' prefix
-            const version = release.data.tag_name.replace('v', '');
+            const version = release.data.tag_name.replace(/^v/, '');
+            const isPreRelease = version.includes('-');
 
             // Create semantic version parts
-            const [major, minor, patch] = version.split('.');
+            const [major, minor] = version.split('.');
             const versionTags = [
-              release.data.tag_name,         // Original tag (vX.Y.Z)
-              version,                  // X.Y.Z
+              release.data.tag_name,    // Original tag (vX.Y.Z[-pre][+build])
+              version,                  // X.Y.Z[-pre][+build]
               `${major}.${minor}`,      // X.Y
               major                     // X
             ];
+            if (!isPreRelease) {
+              versionTags.push('latest')
+            }
 
             core.setOutput('version_tags', versionTags.join(','));
 
@@ -107,7 +111,6 @@ jobs:
 
     env:
       GOOGLE_ARTIFACT_REGISTRY_REPOSITORY: ${{ vars.GOOGLE_ARTIFACT_REGISTRY_REPOSITORY }}
-      GOOGLE_ARTIFACT_REGISTRY_DEFAULT_TAG: ${{ vars.GOOGLE_ARTIFACT_REGISTRY_DEFAULT_TAG }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# Why?

We used `release` tag for last build on `main`, which was a mistake and confusing.

# What?

New convention is:

- `edge` for latest built from main branch
- `latest` for latest released (versioned) one; unless it’s a pre–release

Also drops `GOOGLE_ARTIFACT_REGISTRY_DEFAULT_TAG` in favour of hard–coding
these tags to force uniformity across projects.
