### PR TITLE
chore: Update third party actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Check if we need to install browsers
         id: browsers
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { existsSync } = require('fs');

--- a/.github/workflows/notify-main-branch-failure.yaml
+++ b/.github/workflows/notify-main-branch-failure.yaml
@@ -31,7 +31,7 @@ jobs:
           if [ -z "${{ secrets.SLACK_BOT_TOKEN }}" ]
           then
             # shellcheck disable=SC1111
-            echo "::error::Missing secret SLACK_BOT_TOKEN. Go to https://api.slack.com/apps/, create a bot, go to “OAuth & Permissions”. Add chate:write permission and grab a token."
+            echo "::error::Missing secret SLACK_BOT_TOKEN. Go to https://api.slack.com/apps/, create a bot, go to “OAuth & Permissions”. Add chat:write permission and grab a token."
             exit_code=78
           fi
 

--- a/.github/workflows/ref-comment-in-commit.yaml
+++ b/.github/workflows/ref-comment-in-commit.yaml
@@ -1,0 +1,22 @@
+name: 'Ref Comment in Commit'
+
+# Make it possible to reference a GH comment in a commit message.
+#
+# This file has been created from
+# https://github.com/verkstedt/.github/blob/main/workflow-templates/ref-comment-by-commit.yaml
+#
+# IF YOU MODIFY IT IN ANY WAY, DESCRIBE IT IN THE COMMENT HERE
+# to make updating in the future easier.
+
+on:
+  push:
+
+jobs:
+  ref-comments:
+    name: 'Ref Comment in Commit'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Ref Comment in Commit'
+        uses: 'verkstedt/actions/ref-comment-in-commit@v1'
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ref-comment-in-commit.yaml
+++ b/.github/workflows/ref-comment-in-commit.yaml
@@ -3,7 +3,7 @@ name: 'Ref Comment in Commit'
 # Make it possible to reference a GH comment in a commit message.
 #
 # This file has been created from
-# https://github.com/verkstedt/.github/blob/main/workflow-templates/ref-comment-by-commit.yaml
+# https://github.com/verkstedt/.github/blob/main/workflow-templates/ref-comment-in-commit.yaml
 #
 # IF YOU MODIFY IT IN ANY WAY, DESCRIBE IT IN THE COMMENT HERE
 # to make updating in the future easier.

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -21,7 +21,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: master
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Determine Version
         id: version
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             // If version was provided in input, use that
@@ -62,7 +62,7 @@ jobs:
             }
 
       - name: Generate Notes and Create Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           VERSION: ${{ steps.version.outputs.version }}
           COMMIT: ${{ steps.commit_details.outputs.commit }}

--- a/.github/workflows/reusable-tag-docker-release-images.yml
+++ b/.github/workflows/reusable-tag-docker-release-images.yml
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/reusable-tag-docker-release-images.yml
+++ b/.github/workflows/reusable-tag-docker-release-images.yml
@@ -19,7 +19,7 @@ jobs:
         id: release_details
         env:
           RELEASE_ID: ${{ inputs.release_id }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             let releaseId = process.env.RELEASE_ID;
@@ -126,7 +126,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: google_auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           token_format: access_token
           project_id: ${{ secrets.GOOGLE_PROJECT_ID }}

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -24,13 +24,13 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version-file: '${{ inputs.working-directory }}/.nvmrc'
 

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -19,6 +19,9 @@ outputs:
   scripts:
     description: "Comma–separated list of available npm scripts. Includes comma at the beginning and the end, so you can use contains(needs.setup.outputs.scripts, ',script-name,')"
     value: ${{ steps.scripts.outputs.scripts }}
+  package-manager:
+    description: 'Detected package manager (npm or yarn)'
+    value: ${{ steps.package-manager.outputs.package-manager }}
 
 runs:
   using: composite

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -83,6 +83,22 @@ runs:
       run: |
         echo "//npm.pkg.github.com/:_authToken=${{ inputs.github-npm-registry-personal-access-token }}" >> ~/.npmrc
 
+    - name: Determine package manager
+      id: package-manager
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: |
+        if [ -e "yarn.lock" ]
+        then
+          echo "package-manager=yarn" >> "$GITHUB_OUTPUT"
+        elif [ -e "package-lock.json" ]
+        then
+          echo "package-manager=npm" >> "$GITHUB_OUTPUT"
+        else
+          echo "ERROR: Could not determine package manager. Neither package-lock.json nor yarn.lock found." >&2
+          exit 66 # EX_NOINPUT
+        fi
+
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       working-directory: ${{ inputs.working-directory }}
@@ -96,11 +112,21 @@ runs:
           export GH_REGISTRY_TOKEN="$GITHUB_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN"
         fi
 
-        if [ -e "yarn.lock" ]
+        if [ "${{ steps.package-manager.outputs['package-manager'] }}" = "yarn" ]
         then
           yarn install --immutable
         else
           npm ci
+        fi
+
+    - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
+      if: steps.cache.outputs.cache-hit != 'true' && steps.package-manager.outputs['package-manager'] == 'npm'
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      run: |
+        if [ 0 -lt "$( jq -r '( .dependencies + .devDependencies ) // {} | to_entries | length' package.json )" ]
+        then
+          npm audit signatures
         fi
 
     - name: Run prepare npm script


### PR DESCRIPTION
# Why?

Closes https://verkstedt.atlassian.net/browse/VIP-86

Groundwork for #25 and #26 (not yet ready for review).

# What?

- **Update used actions**

# What else?

- **Typo** in an error message

- **Use ref-comment-in-commit action** in this repository

- **feat(ci): Run npm audit signatures**. https://github.blog/changelog/2022-07-26-a-new-npm-audit-signatures-command-to-verify-npm-package-integrity/

- **feat(ci): Output package-manager** in `setup` action, introducing source of truth for this info, instead of checking for `yarn.lock` file