### PR TITLE
feat(ci): Support new value of vitests browser.provider

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,7 +235,14 @@ jobs:
               const browsers = new Set(
                 vitestConfig.test?.projects
                   ?.filter(proj => proj.test?.browser?.enabled)
-                  .filter(proj => [undefined, 'playwright'].includes(proj.test?.browser?.provider))
+                  .filter(proj => {
+                    const provider = proj.test?.browser?.provider;
+                    return (
+                      provider == undefined
+                      || provider === 'playwright'
+                      || provider?.name === 'playwright'
+                    )
+                  })
                   .flatMap(proj => proj.test?.browser?.instances ?? [{ browser: 'chromium' }])
                   .filter(Boolean)
                   .map(instance => instance?.browser)


### PR DESCRIPTION
# Why?

Vitest v4 changed type of the `browser.provider` option from a string to something you import from a package. Thankfully new value’s `name` property is the same as the old string value.

OLD: https://v3.vitest.dev/guide/browser/config.html#browser-provider
NEW: https://v4.vitest.dev/config/browser/provider
