### PR TITLE
CI: Fix reading vitest config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,21 +224,16 @@ jobs:
         with:
           script: |
             const { resolve } = await import('node:path');
-            const { existsSync } = await import('node:fs');
-            const fileName = [
-              './vitest.config.ts',
-              './vitest.config.js',
-            ]
-              .map(fileName => resolve(
-                '${{ github.workspace }}',
-                '${{ inputs.working-directory }}',
-                fileName
-              ))
-              .find(filePath => existsSync(filePath));
+            const { existsSync, globSync } = await import('node:fs');
+            const fileName = globSync(resolve(
+              '${{ github.workspace }}',
+              '${{ inputs.working-directory }}',
+              './vitest.config.*',
+            )).at(0)
 
             if (fileName) {
               let vitestConfig;
-              // We don’t know if vitest is CJS or ESM. Try both.
+              // We don’t know if vitest config is CJS or ESM. Try both.
               try {
                 vitestConfig = await import(fileName);
               } catch {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,14 +223,27 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const { existsSync } = require('fs');
+            const { resolve } = await import('node:path');
+            const { existsSync } = await import('node:fs');
             const fileName = [
               './vitest.config.ts',
               './vitest.config.js',
-            ].find(f => existsSync(f));
+            ]
+              .map(fileName => resolve(
+                '${{ github.workspace }}',
+                '${{ inputs.working-directory }}',
+                fileName
+              ))
+              .find(filePath => existsSync(filePath));
 
             if (fileName) {
-              let vitestConfig = require(fileName);
+              let vitestConfig;
+              // We don’t know if vitest is CJS or ESM. Try both.
+              try {
+                vitestConfig = await import(fileName);
+              } catch {
+                vitestConfig = require(fileName);
+              }
               vitestConfig = vitestConfig?.default || vitestConfig;
               const browsers = new Set(
                 vitestConfig.test?.projects


### PR DESCRIPTION
# Why?

Change triggered by an action failing because vitest config included top level `await`.

# What?

`ci` workflows reads vitest config to figure out whether to install playwright browsers before running the tests.

Config can be CJS, can be ESM. Project can have `type: module` in package.json or not. New version reads any `vitest.config.*` and tries to use `import` to read it before falling back to `require`.

Tested on a repo that doesn’t need browsers (where initial failure happened) and another one that does need browsers.