### PR TITLE
Pin GitHub Actions to specific versions

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Publish to Chromatic
         id: publish
-        uses: chromaui/action@latest
+        uses: chromaui/action@v13.3.5
         with:
           workingDir: ${{ inputs.working-directory }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Annotate
         if: steps.lint.outputs.generated-eslint-report == 'true'
-        uses: ataylorme/eslint-annotate-action@v3
+        uses: ataylorme/eslint-annotate-action@3.0.0
         with:
           report-json: eslint_report.json
           # Also report errors in files not changed in the PR,
@@ -252,7 +252,7 @@ jobs:
 
       - name: Check if we need to install browsers
         id: browsers
-        uses: actions/github-script@v8
+        uses: actions/github-script@v8.0.0
         with:
           script: |
             const { resolve } = await import('node:path');
@@ -413,7 +413,7 @@ jobs:
 
       - name: Restore cache
         id: cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v5.0.3
         # ⚠ Keep in sync with cache/save below
         with:
           path: |
@@ -432,7 +432,7 @@ jobs:
 
       - name: Save cache
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v5.0.3
         # ⚠ Keep in sync with cache/restore above
         with:
           path: |

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: 'GitHub App token: Token'
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.2.1
         with:
           app-id: ${{ inputs.github-app-id }}
           private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
@@ -105,7 +105,7 @@ jobs:
           echo "user-id=$user_id" >> "$GITHUB_OUTPUT"
 
       - name: 'Checkout'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/deploy-cloudfunction.yaml
+++ b/.github/workflows/deploy-cloudfunction.yaml
@@ -49,16 +49,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - name: Google Auth
-        uses: 'google-github-actions/auth@v3'
+        uses: 'google-github-actions/auth@v3.0.0'
         with:
           service_account: ${{ inputs.workload-identity-service-account-mail }}
           workload_identity_provider: ${{ inputs.workload-identity-provider }}
       - name: Set up gcloud-cli
-        uses: 'google-github-actions/setup-gcloud@v3'
+        uses: 'google-github-actions/setup-gcloud@v3.0.1'
       - name: Deploy Cloud Function
-        uses: google-github-actions/deploy-cloud-functions@v4
+        uses: google-github-actions/deploy-cloud-functions@v4.0.0
         with:
           name: ${{ inputs.function-name }}
           runtime: ${{ inputs.runtime }}

--- a/.github/workflows/deploy-cloudrun.yaml
+++ b/.github/workflows/deploy-cloudrun.yaml
@@ -49,19 +49,19 @@ jobs:
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Validate inputs
         run: |
           if [[ -z "${{ inputs.job-name }}" && -z "${{ inputs.service-name }}" ]]; then
             echo "::error::At least one of 'job-name' or 'service-name' must be provided"
             exit 1
           fi
-      - uses: 'google-github-actions/auth@v3'
+      - uses: 'google-github-actions/auth@v3.0.0'
         with:
           service_account: ${{ inputs.workload-identity-service-account-mail }}
           workload_identity_provider: ${{ inputs.workload-identity-provider }}
       - name: 'Set up gcloud CLI'
-        uses: 'google-github-actions/setup-gcloud@v3'
+        uses: 'google-github-actions/setup-gcloud@v3.0.1'
         with:
           install_components: 'beta'
 

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -183,7 +183,7 @@ jobs:
           fi
 
       - name: 'Checkout'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
 
       - name: 'GitHub Container Registry: Setup'
         if: ${{ inputs.github == true }}
@@ -318,13 +318,13 @@ jobs:
           } | tee -a "$GITHUB_OUTPUT"
 
       - name: 'Set up QEMU'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3.7.0
 
       - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.12.0
 
       - name: 'Build and Push'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.18.0
         with:
           push: ${{ inputs.dry-run != true }}
           cache-from: type=gha

--- a/notify-status/action.yaml
+++ b/notify-status/action.yaml
@@ -39,14 +39,14 @@ runs:
         printf "value<<EOM\n%s\nEOM\n" "$MESSAGE" | tee -a "$GITHUB_OUTPUT"
     - name: Send Slack message
       uses: slackapi/slack-github-action@v2.1.1
-      env:
-        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
       with:
-        channel-id: ${{ inputs.slack-channel-id }}
+        method: chat.postMessage
+        token: ${{ inputs.slack-bot-token }}
         # TIP: Use
         # https://app.slack.com/block-kit-builder/ to preview
         payload: |
           {
+            "channel": "${{ inputs.slack-channel-id }}",
             "text": ${{ toJson(steps.message.outputs.value) }},
             "blocks": [
               {

--- a/notify-status/action.yaml
+++ b/notify-status/action.yaml
@@ -38,7 +38,7 @@ runs:
       run: |
         printf "value<<EOM\n%s\nEOM\n" "$MESSAGE" | tee -a "$GITHUB_OUTPUT"
     - name: Send Slack message
-      uses: slackapi/slack-github-action@v1
+      uses: slackapi/slack-github-action@v2.1.1
       env:
         SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
       with:

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -60,7 +60,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6.0.2
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         lfs: ${{ inputs.lfs }}
@@ -68,7 +68,7 @@ runs:
         token: ${{ inputs.token }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6.2.0
       with:
         node-version-file: '${{ inputs.working-directory }}/.nvmrc'
 
@@ -105,7 +105,7 @@ runs:
 
     - name: Restore cache
       id: cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5.0.3
       # ⚠ Keep in sync with cache/save below
       with:
         path: ${{ steps.cache-paths.outputs.paths }}
@@ -192,7 +192,7 @@ runs:
 
     - name: Save cache
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5.0.3
       # ⚠ Keep in sync with cache/restore above
       with:
         path: ${{ steps.cache-paths.outputs.paths }}


### PR DESCRIPTION
# Why?

When using GitHub actions, you use git references. These can be commit SHAs,
branch names, or tags. For majority of actions we used branch names with major
version only and for `chromaui/action` we used `latest` tag, which meant they
could change without us realising it.

# What?

Update all references to point to git tags, which _hopefully_ will not change.

We do have dependabot configured to check for updates, so we will update them.
