### PR TITLE
Support git submodules

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -52,13 +52,13 @@ jobs:
 
       - name: GitHub App token
         id: app-token
-        uses: verkstedt/actions/create-github-app-token@v1
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
         with:
           app-id: ${{ vars.GH_AUTH_APP_ID }}
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -16,6 +16,11 @@ on:
           https://www.chromatic.com/start, then open your project and go
           to “Manage” → “Configure”.'
         required: true
+      GH_AUTH_APP_SECRET:
+        description: >
+          GitHub App private key for generating tokens.
+          Used in pair with vars.GH_AUTH_APP_ID — set both or neither.
+        required: false
       GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN:
         description: >
           GitHub personal access token for npm registry authentication.
@@ -45,10 +50,18 @@ jobs:
 
           exit $exit_code
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,11 @@ on:
           (DEPRECATED! Use env_vars instead)
           Environment variables to set when running build script.
         required: false
+      GH_AUTH_APP_SECRET:
+        description: >
+          GitHub App private key for generating tokens.
+          Used in pair with vars.GH_AUTH_APP_ID — set both or neither.
+        required: false
       GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN:
         description: >
           GitHub personal access token for npm registry authentication.
@@ -48,11 +53,19 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         id: setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
   lint-js:
@@ -68,10 +81,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       # Once https://github.com/actions/setup-node/issues/96 is
@@ -115,10 +136,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint TS
@@ -138,10 +167,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint CSS
@@ -162,10 +199,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint shell scripts
@@ -186,10 +231,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint Translations
@@ -213,10 +266,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Lint fallback
@@ -244,10 +305,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Check if we need to install browsers
@@ -319,10 +388,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Test end to end
@@ -353,10 +430,18 @@ jobs:
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Test fallback
@@ -398,11 +483,20 @@ jobs:
           ENV_VARS: ${{ secrets.env_vars }}
         run: |
           echo "$ENV_VARS" >> "$GITHUB_ENV"
+
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: Setup
         uses: verkstedt/actions/setup@v1
         with:
           lfs: true
           working-directory: ${{ inputs.working-directory }}
+          token: ${{ steps.app-token.outputs.token }}
           github-npm-registry-personal-access-token: ${{ secrets.GH_NPM_REGISTRY_PERSONAL_ACCESS_TOKEN }}
 
       - name: Calculate cache key parts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,14 +55,14 @@ jobs:
 
       - name: GitHub App token
         id: app-token
-        uses: verkstedt/actions/create-github-app-token@v1
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
         with:
           app-id: ${{ vars.GH_AUTH_APP_ID }}
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
         id: setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -89,7 +89,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -144,7 +144,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -175,7 +175,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -207,7 +207,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -239,7 +239,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -274,7 +274,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -313,7 +313,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -396,7 +396,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -438,7 +438,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           working-directory: ${{ inputs.working-directory }}
           token: ${{ steps.app-token.outputs.token }}
@@ -492,7 +492,7 @@ jobs:
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
 
       - name: Setup
-        uses: verkstedt/actions/setup@v1
+        uses: verkstedt/actions/setup@feat/git-submodules
         with:
           lfs: true
           working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -107,7 +107,6 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v6.0.2
         with:
-          fetch-depth: 1
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/deploy-cloudfunction.yaml
+++ b/.github/workflows/deploy-cloudfunction.yaml
@@ -2,6 +2,12 @@ name: 'Reusable gcp cloud function deploy workflow'
 
 on:
   workflow_call:
+    secrets:
+      GH_AUTH_APP_SECRET:
+        description: >
+          GitHub App private key for generating tokens.
+          Used in pair with vars.GH_AUTH_APP_ID — set both or neither.
+        required: false
     inputs:
       function-name:
         description: 'Name of the Cloud Function to deploy'
@@ -48,8 +54,17 @@ jobs:
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
       - name: Checkout code
         uses: actions/checkout@v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          submodules: recursive
       - name: Google Auth
         uses: 'google-github-actions/auth@v3.0.0'
         with:

--- a/.github/workflows/deploy-cloudrun.yaml
+++ b/.github/workflows/deploy-cloudrun.yaml
@@ -55,16 +55,7 @@ jobs:
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:
-      - name: GitHub App token
-        id: app-token
-        uses: verkstedt/actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.GH_AUTH_APP_ID }}
-          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
       - uses: actions/checkout@v6.0.2
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          submodules: recursive
       - name: Validate inputs
         run: |
           if [[ -z "${{ inputs.job-name }}" && -z "${{ inputs.service-name }}" ]]; then

--- a/.github/workflows/deploy-cloudrun.yaml
+++ b/.github/workflows/deploy-cloudrun.yaml
@@ -2,6 +2,12 @@ name: 'Reusable gcp cloudrun deploy workflow'
 
 on:
   workflow_call:
+    secrets:
+      GH_AUTH_APP_SECRET:
+        description: >
+          GitHub App private key for generating tokens.
+          Used in pair with vars.GH_AUTH_APP_ID — set both or neither.
+        required: false
     inputs:
       job-name:
         description: 'Cloud Run Job name (at least one of job-name or service-name required)'
@@ -49,7 +55,16 @@ jobs:
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
       - uses: actions/checkout@v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          submodules: recursive
       - name: Validate inputs
         run: |
           if [[ -z "${{ inputs.job-name }}" && -z "${{ inputs.service-name }}" ]]; then

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -36,6 +36,11 @@ on:
         description: >
           Slack bot token.
           Required, when `slack-channel-id` is set.
+      GH_AUTH_APP_SECRET:
+        description: >
+          GitHub App private key for generating tokens.
+          Used in pair with vars.GH_AUTH_APP_ID — set both or neither.
+        required: false
 
     inputs:
       dry-run:
@@ -182,8 +187,18 @@ jobs:
             exit 64 # EX_USAGE
           fi
 
+      - name: GitHub App token
+        id: app-token
+        uses: verkstedt/actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.GH_AUTH_APP_ID }}
+          private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
       - name: 'Checkout'
         uses: actions/checkout@v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          submodules: recursive
 
       - name: 'GitHub Container Registry: Setup'
         if: ${{ inputs.github == true }}

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -189,7 +189,7 @@ jobs:
 
       - name: GitHub App token
         id: app-token
-        uses: verkstedt/actions/create-github-app-token@v1
+        uses: verkstedt/actions/create-github-app-token@feat/git-submodules
         with:
           app-id: ${{ vars.GH_AUTH_APP_ID }}
           private-key: ${{ secrets.GH_AUTH_APP_SECRET }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ project and how things are organised and why.
 1. Copy `workflow-templates/*.yaml` files from
    [verkstedt/.github][workflow-templates] (_not_ this repository) to
    `.github/workflows/` in your repository.
-
    - skip `chromatic`, if your project doesn’t use it
    - skip `jira`, if your project doesn’t use it
 
@@ -27,9 +26,7 @@ project and how things are organised and why.
 
 3. You might have these defined on the GitHub organisation level, but
    want to overwrite them with project–specific values:
-
    - `SLACK_CHANNEL_ID` var, if you have a project–specific channel
-
      - In Slack, open the channel.
      - Open the channel details (the channel name on the top of the screen)
      - The channel ID is at the bottom
@@ -41,7 +38,6 @@ project and how things are organised and why.
 
    Some of the checks are skipped for draft PRs, so make sure to
    publish.
-
    1. When workflows run, they will most probably fail, because some
       secrets and/or vars are missing, but error messages should guide
       you where to take them from.
@@ -74,7 +70,8 @@ scripts as paralel jobs:
 - `test` (if no `test:*` scripts present)
 - `build`
 
-&nbsp;<!-- separate lists -->
+> [!TIP]
+> If your repo has git submodules with private repos, you will need some [additional setup](#user-content-submodules).
 
 - [🔍 Repositories using this template](https://github.com/search?q=-is:archived+path:.github/workflows/ci.yaml+"https://github.com/verkstedt/.github/blob/main/workflow-templates/ci.yaml"&type=code)
 - [🔍 Repositories using this workflow](https://github.com/search?q=-is:archived+path:.github/workflows/+"verkstedt/actions/.github/workflows/ci.yaml"+NOT+"https://github.com/verkstedt/.github/blob/main/workflow-templates/ci.yaml"&type=code)
@@ -109,6 +106,9 @@ Runs only on `main` branch and published PRs.
 
 Requires some vars and/or secrets.
 See [./.github/workflows/chromatic.yaml][workflow-chromatic] for details.
+
+> [!TIP]
+> If your repo has git submodules with private repos, you will need some [additional setup](#user-content-submodules).
 
 - [🔍 Repositories using this template](https://github.com/search?q=-is:archived+path:.github/workflows/chromatic.yaml+"https://github.com/verkstedt/.github/blob/main/workflow-templates/chromatic.yaml"&type=code)
 - [🔍 Repositories using this workflow](https://github.com/search?q=-is:archived+path:.github/workflows/+"verkstedt/actions/.github/workflows/chromatic.yaml"+NOT+"https://github.com/verkstedt/.github/blob/main/workflow-templates/chromatic.yaml"&type=code)
@@ -193,6 +193,17 @@ If any of your npm scripts requires any env vars, set `env_vars` secret
 in the repository. Make sure there’s `secrets: inherit` in your
 `ci.yaml`.
 
+<a id="user-content-submodules"></a>
+
+### How to use repositories with private git submodules?
+
+GitHub creates `github.token` that is used for checking out the code, but it has
+access to only the repo it works on. If your repository has git submodules
+pointing to private repositories, you will have to pass a token with access to
+those repositories.
+
+See [`create-github-app-token`](./create-github-app-token).
+
 ### How do I start something that’s required for running tests?
 
 You have two options:
@@ -203,7 +214,6 @@ You have two options:
 
    Let’s assume that your `test` script runs `jest` and you need to run
    `npx mock-server` before.
-
    - Create separate script file, e.g. `./scripts/test.sh`:
 
      ```sh

--- a/create-github-app-token/README.md
+++ b/create-github-app-token/README.md
@@ -1,0 +1,20 @@
+# `verkstedt/actions/create-github-app-token`
+
+Generate a GitHub App token if `app-id` and `private-key` inputs are
+both provided. Falls back to `github.token`.
+
+Example usage:
+
+```yaml
+- name: GitHub App token
+  id: app-token
+  uses: verkstedt/actions/create-github-app-token@v1
+  with:
+    app-id: ${{ vars.GH_AUTH_APP_ID }}
+    private-key: ${{ secrets.GH_AUTH_APP_SECRET }}
+
+- name: Setup
+  uses: verkstedt/actions/setup@v1
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+```

--- a/create-github-app-token/action.yaml
+++ b/create-github-app-token/action.yaml
@@ -1,0 +1,61 @@
+name: GitHub App Token
+description: >
+  Generate a GitHub App token if app-id and private-key inputs are both
+  provided. Falls back to github.token.
+
+inputs:
+  app-id:
+    description: >
+      GitHub App ID (typically passed from vars.GH_AUTH_APP_ID).
+    required: false
+    default: ''
+  private-key:
+    description: >
+      GitHub App private key (typically passed from secrets.GH_AUTH_APP_SECRET).
+    required: false
+    default: ''
+  owner:
+    description: >
+      Owner for the generated token.
+    required: false
+    default: ${{ github.repository_owner }}
+
+outputs:
+  token:
+    description: >
+      The generated GitHub App token, or github.token if the app is not
+      configured.
+    value: ${{ steps.token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check GitHub App configuration
+      id: github-app
+      shell: sh
+      env:
+        HAS_APP_ID: ${{ inputs.app-id && 'true' || 'false' }}
+        HAS_SECRET: ${{ inputs.private-key && 'true' || 'false' }}
+      run: |
+        case "$HAS_APP_ID:$HAS_SECRET" in
+          true:true)  echo "configured=true" >> "$GITHUB_OUTPUT" ;;
+          true:false) echo "::warning::vars.GH_AUTH_APP_ID is set but secrets.GH_AUTH_APP_SECRET is missing. Both are required to generate a GitHub App token. Falling back to github.token." ;;
+          false:true) echo "::warning::secrets.GH_AUTH_APP_SECRET is set but vars.GH_AUTH_APP_ID is missing. Both are required to generate a GitHub App token. Falling back to github.token." ;;
+        esac
+
+    - name: Generate GitHub App token
+      if: steps.github-app.outputs.configured == 'true'
+      id: app-token
+      uses: actions/create-github-app-token@v2.2.1
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+
+    - name: Set token output
+      id: token
+      env:
+        TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+      shell: sh
+      run: |
+        echo "token=$TOKEN" >> "$GITHUB_OUTPUT"

--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -66,6 +66,7 @@ runs:
         lfs: ${{ inputs.lfs }}
         ref: ${{ github.event.pull_request.head.ref || github.ref }}
         token: ${{ inputs.token }}
+        submodules: recursive
 
     - name: Setup Node.js
       uses: actions/setup-node@v6.2.0
@@ -110,7 +111,7 @@ runs:
       with:
         path: ${{ steps.cache-paths.outputs.paths }}
         key: |
-          npm--${{ steps.cache-keys.outputs.os }}--${{ steps.cache-keys.outputs.node }}--${{ steps.cache-keys.outputs.packageJson }}--${{ steps.cache-keys.outputs.packageJsonLock }}
+          npm--${{ steps.cache-keys.outputs.os }}--${{ steps.cache-keys.outputs.node }}--${{ steps.cache-keys.outputs.packageJson }}--${{ steps.cache-keys.outputs.packageJsonLock }}--v2
         restore-keys: |
           npm--${{ steps.cache-keys.outputs.os }}--${{ steps.cache-keys.outputs.node }}--${{ steps.cache-keys.outputs.packageJson }}--
           npm--${{ steps.cache-keys.outputs.os }}--${{ steps.cache-keys.outputs.node }}--
@@ -197,4 +198,4 @@ runs:
       with:
         path: ${{ steps.cache-paths.outputs.paths }}
         key: |
-          npm--${{ steps.cache-keys.outputs.os }}--${{ steps.cache-keys.outputs.node }}--${{ steps.cache-keys.outputs.packageJson }}--${{ steps.cache-keys.outputs.packageJsonLock }}
+          npm--${{ steps.cache-keys.outputs.os }}--${{ steps.cache-keys.outputs.node }}--${{ steps.cache-keys.outputs.packageJson }}--${{ steps.cache-keys.outputs.packageJsonLock }}--v2


### PR DESCRIPTION
## Why?

Fixes https://verkstedt.atlassian.net/browse/TIOSDEV-45

## What?

- New action that calls `create-github-app-token`, but falls back to `github.token` and also yells at you if it’s misconfigured.

- Pass `submodules: recursive` when using `checkout`
  For public repos this will work fine, for private ones, you need to pass a token that can read your repo and submodule. That’s what new action is for.

## TODO before the merge

- [ ] Remove commit that does `@v1` → `@feat/git-submodules`

---

@coderabbitai ignore