### PR TITLE
chore: drop checkout repo from cloudrun deploy job

### DIFF
--- a/.github/workflows/deploy-cloudrun.yaml
+++ b/.github/workflows/deploy-cloudrun.yaml
@@ -55,7 +55,6 @@ jobs:
       id-token: 'write'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
       - name: Validate inputs
         run: |
           if [[ -z "${{ inputs.job-name }}" && -z "${{ inputs.service-name }}" ]]; then


### PR DESCRIPTION
The checkout is not needed here as the deploy is not based on the repo