### PR TITLE
chore: update create-github-app-token action to v3.1.1

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: 'GitHub App token: Token'
         id: app-token
-        uses: actions/create-github-app-token@v2.2.1
+        uses: actions/create-github-app-token@v3.1.1
         with:
           app-id: ${{ inputs.github-app-id }}
           private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}

--- a/create-github-app-token/action.yaml
+++ b/create-github-app-token/action.yaml
@@ -46,7 +46,7 @@ runs:
     - name: Generate GitHub App token
       if: steps.github-app.outputs.configured == 'true'
       id: app-token
-      uses: actions/create-github-app-token@v2.2.1
+      uses: actions/create-github-app-token@v3.1.1
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}


### PR DESCRIPTION
the create-release aciton started to produce deprecation warnings

```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/create-github-app-token@v2.2.1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

---

Closes #59.