### PR TITLE
feat(jira): Minimise stale tip comments

### DIFF
--- a/jira-integration/dist/index.mjs
+++ b/jira-integration/dist/index.mjs
@@ -36165,11 +36165,15 @@ const octokit = getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
 const issueNumber = (payload.pull_request || payload.issue).number
 
+const tipCommentMarker = '<!-- JIRA_INTEGRATION_NAG -->'
+
 /**
  * GitHub data
  *
  * @typedef {object} PullRequestComment
+ * @property {string} id
  * @property {string} body
+ * @property {boolean} isMinimized
  */
 
 /**
@@ -36235,7 +36239,12 @@ const keywords = [
  * @return {Array<IssueKey>}
  */
 function extractResolvedIssueKeys(prBody, comments) {
-  const text = [prBody, ...comments.map((comment) => comment.body)].join('\0')
+  const text = [
+    prBody,
+    ...comments
+      .filter((comment) => !comment.isMinimized)
+      .map((comment) => comment.body),
+  ].join('\0')
 
   const keywordsRegExp = githubRequireKeywordPrefix
     ? `(?:${keywords.join('|')})\\s+`
@@ -36271,15 +36280,72 @@ function extractResolvedIssueKeys(prBody, comments) {
 async function getPullRequestComments() {
   info('Requesting pull request comments')
 
-  return octokit.paginate(octokit.rest.issues.listComments, {
-    owner: repoOwner,
-    repo: payload.repository.name,
-    issue_number: issueNumber,
-    per_page: 100,
-  })
+  const query = `
+    query ($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        issueOrPullRequest(number: $number) {
+          ... on Issue {
+            comments(first: 100, after: $cursor) {
+              nodes { id body isMinimized }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+          ... on PullRequest {
+            comments(first: 100, after: $cursor) {
+              nodes { id body isMinimized }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const comments = []
+  let cursor = null
+  let hasNextPage = true
+  while (hasNextPage) {
+    const result = await octokit.graphql(query, {
+      owner: repoOwner,
+      repo: payload.repository.name,
+      number: issueNumber,
+      cursor,
+    })
+    const page = result.repository.issueOrPullRequest.comments
+    comments.push(...page.nodes)
+    hasNextPage = page.pageInfo.hasNextPage
+    cursor = page.pageInfo.endCursor
+  }
+  return comments
 }
 
-async function postTipCommentLinkJiraIssue(comments) {
+/**
+ * @param {Array<PullRequestComment>} tipComments
+ * @return {Promise<void>}
+ */
+async function minimiseTipComments(tipComments) {
+  if (tipComments.length === 0) return
+
+  info('Issues found — minimising stale tip comment(s).')
+  await Promise.all(
+    tipComments.map(async (tip) => {
+      try {
+        await octokit.graphql(
+          `mutation ($id: ID!) {
+            minimizeComment(input: { subjectId: $id, classifier: RESOLVED }) {
+              minimizedComment { isMinimized }
+            }
+          }`,
+          { id: tip.id }
+        )
+      } catch (error) {
+        core_error(`Failed to minimise tip comment: ${error}`)
+      }
+    })
+  )
+}
+
+async function postTipCommentLinkJiraIssue(tipComments) {
   if (
     // Only post a comment, if acting upon an event that could’ve
     // changed PR body
@@ -36287,13 +36353,7 @@ async function postTipCommentLinkJiraIssue(comments) {
     ['opened', 'edited'].includes(payload.action)
   ) {
     try {
-      const tipCommentMarker = '<!-- JIRA_INTEGRATION_NAG -->'
-
-      const alreadyCommented = comments.some((comment) =>
-        comment.body?.includes(tipCommentMarker)
-      )
-
-      if (alreadyCommented) {
+      if (tipComments.length > 0) {
         info('No issues found, but tip comment already present.')
       } else {
         info('No issues found — posting a tip comment.')
@@ -36460,15 +36520,21 @@ async function transitionIssues(issueKeys, newStatusNames) {
 async function main() {
   try {
     const comments = await getPullRequestComments()
+    const tipComments = comments.filter(
+      (comment) =>
+        !comment.isMinimized && comment.body?.includes(tipCommentMarker)
+    )
     const issueIds = extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
       info('Could not find issue IDs')
       // Only post a tip comment when the PR body could have changed
-      await postTipCommentLinkJiraIssue(comments)
+      await postTipCommentLinkJiraIssue(tipComments)
       return
     }
     info('Found issue IDs:', issueIds.join(', '))
+
+    await minimiseTipComments(tipComments)
 
     // Treat PRs with “draft” or “wip” in brackets at the start or
     // end of the titles like drafts. Useful for orgs on unpaid

--- a/jira-integration/index.mjs
+++ b/jira-integration/index.mjs
@@ -89,11 +89,15 @@ const octokit = github.getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
 const issueNumber = (payload.pull_request || payload.issue).number
 
+const tipCommentMarker = '<!-- JIRA_INTEGRATION_NAG -->'
+
 /**
  * GitHub data
  *
  * @typedef {object} PullRequestComment
+ * @property {string} id
  * @property {string} body
+ * @property {boolean} isMinimized
  */
 
 /**
@@ -159,7 +163,12 @@ const keywords = [
  * @return {Array<IssueKey>}
  */
 function extractResolvedIssueKeys(prBody, comments) {
-  const text = [prBody, ...comments.map((comment) => comment.body)].join('\0')
+  const text = [
+    prBody,
+    ...comments
+      .filter((comment) => !comment.isMinimized)
+      .map((comment) => comment.body),
+  ].join('\0')
 
   const keywordsRegExp = githubRequireKeywordPrefix
     ? `(?:${keywords.join('|')})\\s+`
@@ -195,15 +204,72 @@ function extractResolvedIssueKeys(prBody, comments) {
 async function getPullRequestComments() {
   core.info('Requesting pull request comments')
 
-  return octokit.paginate(octokit.rest.issues.listComments, {
-    owner: repoOwner,
-    repo: payload.repository.name,
-    issue_number: issueNumber,
-    per_page: 100,
-  })
+  const query = `
+    query ($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        issueOrPullRequest(number: $number) {
+          ... on Issue {
+            comments(first: 100, after: $cursor) {
+              nodes { id body isMinimized }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+          ... on PullRequest {
+            comments(first: 100, after: $cursor) {
+              nodes { id body isMinimized }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const comments = []
+  let cursor = null
+  let hasNextPage = true
+  while (hasNextPage) {
+    const result = await octokit.graphql(query, {
+      owner: repoOwner,
+      repo: payload.repository.name,
+      number: issueNumber,
+      cursor,
+    })
+    const page = result.repository.issueOrPullRequest.comments
+    comments.push(...page.nodes)
+    hasNextPage = page.pageInfo.hasNextPage
+    cursor = page.pageInfo.endCursor
+  }
+  return comments
 }
 
-async function postTipCommentLinkJiraIssue(comments) {
+/**
+ * @param {Array<PullRequestComment>} tipComments
+ * @return {Promise<void>}
+ */
+async function minimiseTipComments(tipComments) {
+  if (tipComments.length === 0) return
+
+  core.info('Issues found — minimising stale tip comment(s).')
+  await Promise.all(
+    tipComments.map(async (tip) => {
+      try {
+        await octokit.graphql(
+          `mutation ($id: ID!) {
+            minimizeComment(input: { subjectId: $id, classifier: RESOLVED }) {
+              minimizedComment { isMinimized }
+            }
+          }`,
+          { id: tip.id }
+        )
+      } catch (error) {
+        core.error(`Failed to minimise tip comment: ${error}`)
+      }
+    })
+  )
+}
+
+async function postTipCommentLinkJiraIssue(tipComments) {
   if (
     // Only post a comment, if acting upon an event that could’ve
     // changed PR body
@@ -211,13 +277,7 @@ async function postTipCommentLinkJiraIssue(comments) {
     ['opened', 'edited'].includes(payload.action)
   ) {
     try {
-      const tipCommentMarker = '<!-- JIRA_INTEGRATION_NAG -->'
-
-      const alreadyCommented = comments.some((comment) =>
-        comment.body?.includes(tipCommentMarker)
-      )
-
-      if (alreadyCommented) {
+      if (tipComments.length > 0) {
         core.info('No issues found, but tip comment already present.')
       } else {
         core.info('No issues found — posting a tip comment.')
@@ -384,15 +444,21 @@ async function transitionIssues(issueKeys, newStatusNames) {
 async function main() {
   try {
     const comments = await getPullRequestComments()
+    const tipComments = comments.filter(
+      (comment) =>
+        !comment.isMinimized && comment.body?.includes(tipCommentMarker)
+    )
     const issueIds = extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
       core.info('Could not find issue IDs')
       // Only post a tip comment when the PR body could have changed
-      await postTipCommentLinkJiraIssue(comments)
+      await postTipCommentLinkJiraIssue(tipComments)
       return
     }
     core.info('Found issue IDs:', issueIds.join(', '))
+
+    await minimiseTipComments(tipComments)
 
     // Treat PRs with “draft” or “wip” in brackets at the start or
     // end of the titles like drafts. Useful for orgs on unpaid


### PR DESCRIPTION
# Why?

When a PR body is missing a Jira issue link, the action posts a tip comment nagging the author to add one. Once the link is added, the now-irrelevant comment lingered on the PR forever.

# What?

- When issues are found in the PR body, minimise any existing tip comment(s) with classifier `RESOLVED`.
- When checking whether the tip was already posted, skip minimised comments (so a freshly-unlinked PR gets re-nagged).
- Switched comment fetching from REST to GraphQL to get `id` + `isMinimized`.

## Checklist

- [x] Ran \`prettier -w .\`
- [x] Ran \`npm run build\`