### PR TITLE
fix(ref-comment-in-commit): Avoid ncc mangling broken destructuring

### DIFF
--- a/ref-comment-in-commit/dist/index.mjs
+++ b/ref-comment-in-commit/dist/index.mjs
@@ -36055,7 +36055,7 @@ __nccwpck_require__.a(__webpack_module__, async (__webpack_handle_async_dependen
 
 
 
-const { /* context */ "_" = {} } = _actions_github__WEBPACK_IMPORTED_MODULE_1__
+const context = _actions_github__WEBPACK_IMPORTED_MODULE_1__/* .context */ ._ ?? {}
 const { payload } = context
 
 const token = _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4('token')

--- a/ref-comment-in-commit/index.mjs
+++ b/ref-comment-in-commit/index.mjs
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 
-const { context = {} } = github
+const context = github.context ?? {}
 const { payload } = context
 
 const token = core.getInput('token')


### PR DESCRIPTION
## Why?

The built `ref-comment-in-commit/dist/index.mjs` fails `node --check` with `SyntaxError: Unexpected string`, so the action would not run.

ncc 0.38.4 (webpack 5.94.0) mangles `const { context = {} } = github` into invalid JS:

```js
const { /* context */ "_" = {} } = _actions_github__WEBPACK_IMPORTED_MODULE_1__
```

The `mangleExports` optimisation rewrites the export name but not the destructuring-with-default site, emitting the mangled key as a string literal in shorthand position. ncc 0.38.4 is the latest release and bundles webpack 5.94.0, so there is no newer version to upgrade to — the workaround has to live in our source.

## What?

- Rewrite `const { context = {} } = github` as `const context = github.context ?? {}`. Plain property access mangles cleanly (`._ ?? {}`) and stays valid.
- Rebuild `dist/`; it now passes `node --check`.

---

```
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
```