### PR TITLE
fix(repo-hygiene): Skip non-collaborator reviewers

### DIFF
--- a/repo-hygiene/dist/index.mjs
+++ b/repo-hygiene/dist/index.mjs
@@ -47821,8 +47821,8 @@ async function main() {
           repo: repoSlug,
           action: 'dry-run',
           reviewers: [
-            ...reviewerUsers,
-            ...reviewerTeams.map((t) => `${org}/${t}`),
+            ...reviewerUsers.map((u) => `@${u}`),
+            ...reviewerTeams.map((t) => `@${org}/${t}`),
           ],
           unresolvedOwner: hasUnresolvedOwner,
         })
@@ -47883,21 +47883,41 @@ async function main() {
         body: prBody,
       })
 
-      // Request reviewers
+      // Request reviewers one at a time. requestReviewers is
+      // all-or-nothing: a single invalid entry (e.g. a past contributor
+      // who is no longer a collaborator, or a team without repo access)
+      // 422s the whole call. Requesting each reviewer separately — calls
+      // are additive — means a bad entry only drops itself while the
+      // valid reviewers still get assigned.
       const reviewerList = []
-      if (reviewerUsers.length > 0 || reviewerTeams.length > 0) {
+      for (const user of reviewerUsers) {
         try {
           await octokit.rest.pulls.requestReviewers({
             owner: org,
             repo,
             pull_number: pr.data.number,
-            reviewers: reviewerUsers,
-            team_reviewers: reviewerTeams,
+            reviewers: [user],
           })
-          reviewerList.push(...reviewerUsers.map((u) => `@${u}`))
-          reviewerList.push(...reviewerTeams.map((t) => `@${org}/${t}`))
+          reviewerList.push(`@${user}`)
         } catch (e) {
-          warning(`${logPrefix} could not request reviewers: ${e.message}`)
+          warning(
+            `${logPrefix} could not request reviewer @${user}: ${e.message}`
+          )
+        }
+      }
+      for (const team of reviewerTeams) {
+        try {
+          await octokit.rest.pulls.requestReviewers({
+            owner: org,
+            repo,
+            pull_number: pr.data.number,
+            team_reviewers: [team],
+          })
+          reviewerList.push(`@${org}/${team}`)
+        } catch (e) {
+          warning(
+            `${logPrefix} could not request team reviewer @${org}/${team}: ${e.message}`
+          )
         }
       }
 

--- a/repo-hygiene/index.mjs
+++ b/repo-hygiene/index.mjs
@@ -723,8 +723,8 @@ async function main() {
           repo: repoSlug,
           action: 'dry-run',
           reviewers: [
-            ...reviewerUsers,
-            ...reviewerTeams.map((t) => `${org}/${t}`),
+            ...reviewerUsers.map((u) => `@${u}`),
+            ...reviewerTeams.map((t) => `@${org}/${t}`),
           ],
           unresolvedOwner: hasUnresolvedOwner,
         })
@@ -785,21 +785,41 @@ async function main() {
         body: prBody,
       })
 
-      // Request reviewers
+      // Request reviewers one at a time. requestReviewers is
+      // all-or-nothing: a single invalid entry (e.g. a past contributor
+      // who is no longer a collaborator, or a team without repo access)
+      // 422s the whole call. Requesting each reviewer separately — calls
+      // are additive — means a bad entry only drops itself while the
+      // valid reviewers still get assigned.
       const reviewerList = []
-      if (reviewerUsers.length > 0 || reviewerTeams.length > 0) {
+      for (const user of reviewerUsers) {
         try {
           await octokit.rest.pulls.requestReviewers({
             owner: org,
             repo,
             pull_number: pr.data.number,
-            reviewers: reviewerUsers,
-            team_reviewers: reviewerTeams,
+            reviewers: [user],
           })
-          reviewerList.push(...reviewerUsers.map((u) => `@${u}`))
-          reviewerList.push(...reviewerTeams.map((t) => `@${org}/${t}`))
+          reviewerList.push(`@${user}`)
         } catch (e) {
-          core.warning(`${logPrefix} could not request reviewers: ${e.message}`)
+          core.warning(
+            `${logPrefix} could not request reviewer @${user}: ${e.message}`
+          )
+        }
+      }
+      for (const team of reviewerTeams) {
+        try {
+          await octokit.rest.pulls.requestReviewers({
+            owner: org,
+            repo,
+            pull_number: pr.data.number,
+            team_reviewers: [team],
+          })
+          reviewerList.push(`@${org}/${team}`)
+        } catch (e) {
+          core.warning(
+            `${logPrefix} could not request team reviewer @${org}/${team}: ${e.message}`
+          )
         }
       }
 


### PR DESCRIPTION
## Why?

`requestReviewers` is all-or-nothing: GitHub rejects the entire call if any single requested reviewer isn't a collaborator on the repo. The contributors fallback often lists past contributors who no longer have access, so one stale login would drop *all* reviewers and leave only:

> could not request reviewers: Reviews may only be requested from collaborators…

---

```
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Reviewed-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Reviewed-by: Codex gpt-5.5 <codex@openai.com>
Reviewed-by: CodeRabbit 0.5.2 <noreply@coderabbit.ai>
Reviewed-by: Gemini gemini-2.5-pro <gemini-code-assist@google.com>
```