### PR TITLE
fix(ci): Run check-licenses in its own repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -324,8 +324,19 @@ jobs:
           output_file=$(mktemp)
           trap 'rm -f "$output_file"' EXIT
 
+          package='@verkstedt/check-licenses'
+          # In the check-licenses repo itself npx would resolve the
+          # package name to the local workspace, whose bin is never
+          # linked into its own node_modules/.bin — run the local
+          # package via a path instead. Bonus: it checks the code
+          # under test.
+          if [ "$( jq -r '.name' package.json )" = "$package" ]
+          then
+            package='.'
+          fi
+
           set +e
-          npx --yes @verkstedt/check-licenses \
+          npx --yes "$package" \
             --allow-licenses="$LICENSE_CHECK_ALLOW_LICENSES_GLOBAL" \
             --allow-licenses="$LICENSE_CHECK_ALLOW_LICENSES" \
             --allow-licenses-dev="$LICENSE_CHECK_ALLOW_LICENSES_DEV_GLOBAL" \


### PR DESCRIPTION
The “Check licenses” CI job has never passed in the `verkstedt/check-licenses` repo itself: it always fails with `sh: 1: check-licenses: not found` (exit 127).

Cause: `npm exec`/`npx` resolves a requested package name that matches the local workspace to the local project instead of the registry — and npm never links a project’s own bin into its own `node_modules/.bin`, so the `check-licenses` command is not on `PATH`. Pinning a version or using `--package` does not help; npm still prefers the local workspace.

Fix: when the checked project’s `package.json` name is `@verkstedt/check-licenses`, run `npx --yes .` (a path spec, which installs and links the bin properly) instead of the package name. Every other repo keeps the exact same behaviour. Bonus: the check-licenses repo now dogfoods the code under test instead of the last published version.

Verified locally: the name-match branch runs the CLI correctly inside the check-licenses repo, and `npx --yes @verkstedt/check-licenses` still works unchanged elsewhere. `actionlint` passes.

---

```
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)