### PR TITLE
fix(repo-hygiene): Fit the Slack summary into one section block

### DIFF
--- a/notify-status/action.yaml
+++ b/notify-status/action.yaml
@@ -36,6 +36,21 @@ runs:
           }}
       shell: bash
       run: |
+        # The message goes into a single Block Kit section block, whose
+        # text holds at most 3000 characters (`<!here> ` included), per
+        # https://docs.slack.dev/reference/block-kit/blocks/section-block
+        # Truncate, rather than have Slack reject the whole message and
+        # leave us with no notification at all.
+        max=2900
+        marker='… (truncated)'
+        if [ "${#MESSAGE}" -gt "$max" ]; then
+          MESSAGE="${MESSAGE:0:$(( max - ${#marker} - 1 ))}"
+          # Back off to a line boundary, so a `<url|label>` link is not
+          # cut in half and rendered as plain text.
+          MESSAGE="${MESSAGE%$'\n'*}"
+          MESSAGE="${MESSAGE}"$'\n'"${marker}"
+          echo "::warning::Slack message truncated to fit a Block Kit section block"
+        fi
         printf "value<<EOM\n%s\nEOM\n" "$MESSAGE" | tee -a "$GITHUB_OUTPUT"
     - name: Send Slack message
       uses: slackapi/slack-github-action@v3.0.3

--- a/repo-hygiene/action.yaml
+++ b/repo-hygiene/action.yaml
@@ -34,7 +34,9 @@ outputs:
   results_json:
     description: JSON-encoded list of per-repo result objects.
   slack_text:
-    description: Pre-formatted run summary suitable for Slack `text:`.
+    description: >
+      Pre-formatted run summary suitable for Slack `text:`, sized to fit
+      a single Block Kit section block.
   should_notify:
     description: '`true` when there are opened or failed repos worth posting.'
   slack_status:

--- a/repo-hygiene/dist/index.mjs
+++ b/repo-hygiene/dist/index.mjs
@@ -4173,7 +4173,13 @@ function processHeader (request, key, val) {
       } else if (typeof val[i] === 'object') {
         throw new InvalidArgumentError(`invalid ${key} header`)
       } else {
-        arr.push(`${val[i]}`)
+        // Coerce primitives (and reject unsafe coercions such as functions
+        // with a crafted toString/Symbol.toPrimitive).
+        const str = `${val[i]}`
+        if (!isValidHeaderValue(str)) {
+          throw new InvalidArgumentError(`invalid ${key} header`)
+        }
+        arr.push(str)
       }
     }
     val = arr
@@ -4184,7 +4190,12 @@ function processHeader (request, key, val) {
   } else if (val === null) {
     val = ''
   } else {
+    // Coerce primitives (and reject unsafe coercions such as functions
+    // with a crafted toString/Symbol.toPrimitive).
     val = `${val}`
+    if (!isValidHeaderValue(val)) {
+      throw new InvalidArgumentError(`invalid ${key} header`)
+    }
   }
 
   if (headerName === 'host') {
@@ -5218,7 +5229,6 @@ function defaultFactory (origin, opts) {
 
 class Agent extends DispatcherBase {
   constructor ({ factory = defaultFactory, maxRedirections = 0, connect, ...options } = {}) {
-
     if (typeof factory !== 'function') {
       throw new InvalidArgumentError('factory must be a function.')
     }
@@ -5557,6 +5567,7 @@ const {
   RequestContentLengthMismatchError,
   ResponseContentLengthMismatchError,
   RequestAbortedError,
+  InvalidArgumentError,
   HeadersTimeoutError,
   HeadersOverflowError,
   SocketError,
@@ -5604,6 +5615,9 @@ const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
 const addListener = util.addListener
 const removeAllListeners = util.removeAllListeners
+const kIdleSocketValidation = Symbol('kIdleSocketValidation')
+const kIdleSocketValidationTimeout = Symbol('kIdleSocketValidationTimeout')
+const kSocketUsed = Symbol('kSocketUsed')
 
 let extractBody
 
@@ -5826,27 +5840,69 @@ class Parser {
 
       const offset = llhttp.llhttp_get_error_pos(this.ptr) - currentBufferPtr
 
-      if (ret === constants.ERROR.PAUSED_UPGRADE) {
-        this.onUpgrade(data.slice(offset))
-      } else if (ret === constants.ERROR.PAUSED) {
-        this.paused = true
-        socket.unshift(data.slice(offset))
-      } else if (ret !== constants.ERROR.OK) {
-        const ptr = llhttp.llhttp_get_error_reason(this.ptr)
-        let message = ''
-        /* istanbul ignore else: difficult to make a test case for */
-        if (ptr) {
-          const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0)
-          message =
-            'Response does not match the HTTP/1.1 protocol (' +
-            Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
-            ')'
+      if (ret !== constants.ERROR.OK) {
+        const body = data.subarray(offset)
+
+        if (ret === constants.ERROR.PAUSED_UPGRADE) {
+          this.onUpgrade(body)
+        } else if (ret === constants.ERROR.PAUSED) {
+          this.paused = true
+          socket.unshift(body)
+        } else {
+          throw this.createError(ret, body)
         }
-        throw new HTTPParserError(message, constants.ERROR[ret], data.slice(offset))
       }
     } catch (err) {
       util.destroy(socket, err)
     }
+  }
+
+  finish () {
+    assert(currentParser === null)
+    assert(this.ptr != null)
+    assert(!this.paused)
+
+    const { llhttp } = this
+
+    let ret
+
+    try {
+      currentParser = this
+      ret = llhttp.llhttp_finish(this.ptr)
+    } finally {
+      currentParser = null
+    }
+
+    if (ret === constants.ERROR.OK) {
+      return null
+    }
+
+    if (ret === constants.ERROR.PAUSED || ret === constants.ERROR.PAUSED_UPGRADE) {
+      this.paused = true
+      return null
+    }
+
+    return this.createError(ret, EMPTY_BUF)
+  }
+
+  createError (ret, data) {
+    const { llhttp, contentLength, bytesRead } = this
+
+    if (contentLength && bytesRead !== parseInt(contentLength, 10)) {
+      return new ResponseContentLengthMismatchError()
+    }
+
+    const ptr = llhttp.llhttp_get_error_reason(this.ptr)
+    let message = ''
+    if (ptr) {
+      const len = new Uint8Array(llhttp.memory.buffer, ptr).indexOf(0)
+      message =
+        'Response does not match the HTTP/1.1 protocol (' +
+        Buffer.from(llhttp.memory.buffer, ptr, len).toString() +
+        ')'
+    }
+
+    return new HTTPParserError(message, constants.ERROR[ret], data)
   }
 
   destroy () {
@@ -5873,6 +5929,11 @@ class Parser {
 
     /* istanbul ignore next: difficult to make a test case for */
     if (socket.destroyed) {
+      return -1
+    }
+
+    if (client[kRunning] === 0) {
+      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)))
       return -1
     }
 
@@ -5976,6 +6037,11 @@ class Parser {
 
     /* istanbul ignore next: difficult to make a test case for */
     if (socket.destroyed) {
+      return -1
+    }
+
+    if (client[kRunning] === 0) {
+      util.destroy(socket, new SocketError('bad response', util.getSocketInfo(socket)))
       return -1
     }
 
@@ -6152,6 +6218,7 @@ class Parser {
     request.onComplete(headers)
 
     client[kQueue][client[kRunningIdx]++] = null
+    socket[kSocketUsed] = true
 
     if (socket[kWriting]) {
       assert(client[kRunning] === 0)
@@ -6210,6 +6277,9 @@ async function connectH1 (client, socket) {
   socket[kWriting] = false
   socket[kReset] = false
   socket[kBlocking] = false
+  socket[kIdleSocketValidation] = 0
+  socket[kIdleSocketValidationTimeout] = null
+  socket[kSocketUsed] = false
   socket[kParser] = new Parser(client, socket, llhttpInstance)
 
   addListener(socket, 'error', function (err) {
@@ -6220,8 +6290,11 @@ async function connectH1 (client, socket) {
     // On Mac OS, we get an ECONNRESET even if there is a full body to be forwarded
     // to the user.
     if (err.code === 'ECONNRESET' && parser.statusCode && !parser.shouldKeepAlive) {
-      // We treat all incoming data so for as a valid response.
-      parser.onMessageComplete()
+      const parserErr = parser.finish()
+      if (parserErr) {
+        this[kError] = parserErr
+        this[kClient][kOnError](parserErr)
+      }
       return
     }
 
@@ -6240,8 +6313,10 @@ async function connectH1 (client, socket) {
     const parser = this[kParser]
 
     if (parser.statusCode && !parser.shouldKeepAlive) {
-      // We treat all incoming data so far as a valid response.
-      parser.onMessageComplete()
+      const parserErr = parser.finish()
+      if (parserErr) {
+        util.destroy(this, parserErr)
+      }
       return
     }
 
@@ -6251,10 +6326,11 @@ async function connectH1 (client, socket) {
     const client = this[kClient]
     const parser = this[kParser]
 
+    clearIdleSocketValidation(this)
+
     if (parser) {
       if (!this[kError] && parser.statusCode && !parser.shouldKeepAlive) {
-        // We treat all incoming data so far as a valid response.
-        parser.onMessageComplete()
+        this[kError] = parser.finish() || this[kError]
       }
 
       this[kParser].destroy()
@@ -6317,7 +6393,7 @@ async function connectH1 (client, socket) {
       return socket.destroyed
     },
     busy (request) {
-      if (socket[kWriting] || socket[kReset] || socket[kBlocking]) {
+      if (socket[kWriting] || socket[kReset] || socket[kBlocking] || socket[kIdleSocketValidation] === 1) {
         return true
       }
 
@@ -6355,6 +6431,31 @@ async function connectH1 (client, socket) {
   }
 }
 
+function clearIdleSocketValidation (socket) {
+  if (socket[kIdleSocketValidationTimeout]) {
+    clearTimeout(socket[kIdleSocketValidationTimeout])
+    socket[kIdleSocketValidationTimeout] = null
+  }
+
+  socket[kIdleSocketValidation] = 0
+}
+
+function scheduleIdleSocketValidation (client, socket) {
+  socket[kIdleSocketValidation] = 1
+  socket[kIdleSocketValidationTimeout] = setTimeout(() => {
+    socket[kIdleSocketValidationTimeout] = null
+    socket[kIdleSocketValidation] = 2
+
+    if (client[kSocket] === socket && !socket.destroyed) {
+      client[kResume]()
+    }
+  }, 0)
+  socket[kIdleSocketValidationTimeout].unref?.()
+}
+
+/**
+ * @param {import('./client.js')} client
+ */
 function resumeH1 (client) {
   const socket = client[kSocket]
 
@@ -6367,6 +6468,32 @@ function resumeH1 (client) {
     } else if (socket[kNoRef] && socket.ref) {
       socket.ref()
       socket[kNoRef] = false
+    }
+
+    if (client[kRunning] === 0 && client[kPending] > 0 && socket[kSocketUsed]) {
+      if (socket[kIdleSocketValidation] === 0) {
+        scheduleIdleSocketValidation(client, socket)
+        socket[kParser].readMore()
+        if (socket.destroyed) {
+          return
+        }
+        return
+      }
+
+      if (socket[kIdleSocketValidation] === 1) {
+        socket[kParser].readMore()
+        if (socket.destroyed) {
+          return
+        }
+        return
+      }
+    }
+
+    if (client[kRunning] === 0) {
+      socket[kParser].readMore()
+      if (socket.destroyed) {
+        return
+      }
     }
 
     if (client[kSize] === 0) {
@@ -6424,8 +6551,16 @@ function writeH1 (client, request) {
     }
     body = bodyStream.stream
     contentLength = bodyStream.length
-  } else if (util.isBlobLike(body) && request.contentType == null && body.type) {
-    headers.push('content-type', body.type)
+  } else if (util.isBlobLike(body) && request.contentType == null) {
+    const contentType = body.type
+    if (contentType) {
+      const contentTypeValue = `${contentType}`
+      if (!util.isValidHeaderValue(contentTypeValue)) {
+        util.errorRequest(client, request, new InvalidArgumentError('invalid content-type header'))
+        return false
+      }
+      headers.push('content-type', contentTypeValue)
+    }
   }
 
   if (body && typeof body.read === 'function') {
@@ -6462,6 +6597,7 @@ function writeH1 (client, request) {
   }
 
   const socket = client[kSocket]
+  clearIdleSocketValidation(socket)
 
   const abort = (err) => {
     if (request.aborted || request.completed) {
@@ -8331,6 +8467,7 @@ class DispatcherBase extends Dispatcher {
 
   get webSocketOptions () {
     return {
+      maxFragments: this[kWebSocketOptions].maxFragments ?? 131072,
       maxPayloadSize: this[kWebSocketOptions].maxPayloadSize ?? 128 * 1024 * 1024
     }
   }
@@ -9896,6 +10033,28 @@ function calculateRetryAfterHeader (retryAfter) {
   return new Date(retryAfter).getTime() - current
 }
 
+function validatePartialResponseContentLength (headers, range, statusCode, retryCount) {
+  const contentLength = headers['content-length']
+  if (contentLength == null) {
+    return null
+  }
+
+  if (!Number.isFinite(range.start) || !Number.isFinite(range.end)) {
+    return null
+  }
+
+  const length = Number(contentLength)
+  const expectedLength = range.end - range.start + 1
+  if (!Number.isFinite(length) || length !== expectedLength) {
+    return new RequestRetryError('Content-Length mismatch', statusCode, {
+      headers,
+      data: { count: retryCount }
+    })
+  }
+
+  return null
+}
+
 class RetryHandler {
   constructor (opts, handlers) {
     const { retryOptions, ...dispatchOpts } = opts
@@ -10110,6 +10269,12 @@ class RetryHandler {
         return false
       }
 
+      const contentLengthError = validatePartialResponseContentLength(headers, contentRange, statusCode, this.retryCount)
+      if (contentLengthError != null) {
+        this.abort(contentLengthError)
+        return false
+      }
+
       const { start, size, end = size - 1 } = contentRange
 
       assert(this.start === start, 'content-range mismatch')
@@ -10131,6 +10296,12 @@ class RetryHandler {
             resume,
             statusMessage
           )
+        }
+
+        const contentLengthError = validatePartialResponseContentLength(headers, range, statusCode, this.retryCount)
+        if (contentLengthError != null) {
+          this.abort(contentLengthError)
+          return false
         }
 
         const { start, size, end = size - 1 } = range
@@ -14230,32 +14401,25 @@ function parseUnparsedAttributes (unparsedAttributes, cookieAttributeList = {}) 
     // If the attribute-name case-insensitively matches the string
     // "SameSite", the user agent MUST process the cookie-av as follows:
 
-    // 1. Let enforcement be "Default".
-    let enforcement = 'Default'
-
     const attributeValueLowercase = attributeValue.toLowerCase()
-    // 2. If cookie-av's attribute-value is a case-insensitive match for
-    //    "None", set enforcement to "None".
-    if (attributeValueLowercase.includes('none')) {
-      enforcement = 'None'
-    }
 
-    // 3. If cookie-av's attribute-value is a case-insensitive match for
-    //    "Strict", set enforcement to "Strict".
-    if (attributeValueLowercase.includes('strict')) {
-      enforcement = 'Strict'
+    // 1. If cookie-av's attribute-value is a case-insensitive match for
+    //    "None", append an attribute to the cookie-attribute-list with an
+    //    attribute-name of "SameSite" and an attribute-value of "None".
+    if (attributeValueLowercase === 'none') {
+      cookieAttributeList.sameSite = 'None'
+    } else if (attributeValueLowercase === 'strict') {
+      // 2. If cookie-av's attribute-value is a case-insensitive match for
+      //    "Strict", append an attribute to the cookie-attribute-list with
+      //    an attribute-name of "SameSite" and an attribute-value of
+      //    "Strict".
+      cookieAttributeList.sameSite = 'Strict'
+    } else if (attributeValueLowercase === 'lax') {
+      // 3. If cookie-av's attribute-value is a case-insensitive match for
+      //    "Lax", append an attribute to the cookie-attribute-list with an
+      //    attribute-name of "SameSite" and an attribute-value of "Lax".
+      cookieAttributeList.sameSite = 'Lax'
     }
-
-    // 4. If cookie-av's attribute-value is a case-insensitive match for
-    //    "Lax", set enforcement to "Lax".
-    if (attributeValueLowercase.includes('lax')) {
-      enforcement = 'Lax'
-    }
-
-    // 5. Append an attribute to the cookie-attribute-list with an
-    //    attribute-name of "SameSite" and an attribute-value of
-    //    enforcement.
-    cookieAttributeList.sameSite = enforcement
   } else {
     cookieAttributeList.unparsed ??= []
 
@@ -14384,7 +14548,7 @@ function validateCookiePath (path) {
 
     if (
       code < 0x20 || // exclude CTLs (0-31)
-      code === 0x7F || // DEL
+      code > 0x7E || // exclude DEL and non-ascii
       code === 0x3B // ;
     ) {
       throw new Error('Invalid cookie path')
@@ -14393,16 +14557,80 @@ function validateCookiePath (path) {
 }
 
 /**
- * I have no idea why these values aren't allowed to be honest,
- * but Deno tests these. - Khafra
+ * <let-dig> ::= <letter> | <digit>
+ *
+ * <letter> ::= any one of the 52 alphabetic characters A through Z in
+ * upper case and a through z in lower case
+ *
+ * <digit> ::= any one of the ten digits 0 through 9r
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc1034#section-3.5
+ * @param {number} code
+ */
+function isLetterOrDigit (code) {
+  return (
+    (code >= 0x30 && code <= 0x39) || // 0-9
+    (code >= 0x41 && code <= 0x5A) || // A-Z
+    (code >= 0x61 && code <= 0x7A) // a-z
+  )
+}
+
+/**
+ * Validates a cookie domain against the "preferred name syntax".
+ *
+ * <domain>      ::= <subdomain> | " "
+ * <subdomain>   ::= <label> | <subdomain> "." <label>
+ * <label>       ::= <let-dig> [ [ <ldh-str> ] <let-dig> ]
+ * <ldh-str>     ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+ * <let-dig-hyp> ::= <let-dig> | "-"
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc1034#section-3.5
+ * @see https://www.rfc-editor.org/rfc/rfc1123#section-2.1
+ * @see https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4
  * @param {string} domain
  */
 function validateCookieDomain (domain) {
-  if (
-    domain.startsWith('-') ||
-    domain.endsWith('.') ||
-    domain.endsWith('-')
-  ) {
+  // <domain> ::= <subdomain> | " "
+  if (domain === ' ') {
+    return
+  }
+
+  if (domain.length > 255) {
+    throw new Error('Invalid cookie domain')
+  }
+
+  let labelLength = 0
+
+  for (let i = 0; i < domain.length; ++i) {
+    const code = domain.charCodeAt(i)
+
+    if (code === 0x2E) {
+      if (labelLength === 0) {
+        throw new Error('Invalid cookie domain')
+      }
+
+      if (domain.charCodeAt(i - 1) === 0x2D) { // "-"
+        throw new Error('Invalid cookie domain')
+      }
+
+      labelLength = 0
+      continue
+    }
+
+    if (labelLength === 0 && !isLetterOrDigit(code)) {
+      throw new Error('Invalid cookie domain')
+    }
+
+    if (!isLetterOrDigit(code) && code !== 0x2D) { // "-"
+      throw new Error('Invalid cookie domain')
+    }
+
+    if (++labelLength > 63) {
+      throw new Error('Invalid cookie domain')
+    }
+  }
+
+  if (labelLength === 0 || domain.charCodeAt(domain.length - 1) === 0x2D) { // "-"
     throw new Error('Invalid cookie domain')
   }
 }
@@ -14545,7 +14773,13 @@ function stringify (cookie) {
 
     const [key, ...value] = part.split('=')
 
-    out.push(`${key.trim()}=${value.join('=')}`)
+    const trimmedKey = key.trim()
+    const joinedValue = value.join('=')
+
+    validateCookieName(trimmedKey)
+    validateCookieValue(joinedValue)
+
+    out.push(`${trimmedKey}=${joinedValue}`)
   }
 
   return out.join('; ')
@@ -27051,6 +27285,11 @@ const { closeWebSocketConnection } = __nccwpck_require__(4347)
 const { PerMessageDeflate } = __nccwpck_require__(767)
 const { MessageSizeExceededError } = __nccwpck_require__(5793)
 
+function failWebsocketConnectionWithCode (ws, code, reason) {
+  closeWebSocketConnection(ws, code, reason, Buffer.byteLength(reason))
+  failWebsocketConnection(ws, reason)
+}
+
 // This code was influenced by ws released under the MIT license.
 // Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 // Copyright (c) 2013 Arnout Kazemier and contributors
@@ -27071,18 +27310,22 @@ class ByteParser extends Writable {
   #extensions
 
   /** @type {number} */
+  #maxFragments
+
+  /** @type {number} */
   #maxPayloadSize
 
   /**
    * @param {import('./websocket').WebSocket} ws
    * @param {Map<string, string>|null} extensions
-   * @param {{ maxPayloadSize?: number }} [options]
+   * @param {{ maxFragments?: number, maxPayloadSize?: number }} [options]
    */
   constructor (ws, extensions, options = {}) {
     super()
 
     this.ws = ws
     this.#extensions = extensions == null ? new Map() : extensions
+    this.#maxFragments = options.maxFragments ?? 0
     this.#maxPayloadSize = options.maxPayloadSize ?? 0
 
     if (this.#extensions.has('permessage-deflate')) {
@@ -27106,9 +27349,9 @@ class ByteParser extends Writable {
     if (
       this.#maxPayloadSize > 0 &&
       !isControlFrame(this.#info.opcode) &&
-      this.#info.payloadLength > this.#maxPayloadSize
+      this.#info.payloadLength + this.#fragmentsBytes > this.#maxPayloadSize
     ) {
-      failWebsocketConnection(this.ws, 'Payload size exceeds maximum allowed size')
+      failWebsocketConnectionWithCode(this.ws, 1009, 'Payload size exceeds maximum allowed size')
       return false
     }
 
@@ -27273,10 +27516,12 @@ class ByteParser extends Writable {
           this.#state = parserStates.INFO
         } else {
           if (!this.#info.compressed) {
-            this.writeFragments(body)
+            if (!this.writeFragments(body)) {
+              return
+            }
 
             if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
-              failWebsocketConnection(this.ws, new MessageSizeExceededError().message)
+              failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message)
               return
             }
 
@@ -27295,14 +27540,17 @@ class ByteParser extends Writable {
               this.#info.fin,
               (error, data) => {
                 if (error) {
-                  failWebsocketConnection(this.ws, error.message)
+                  const code = error instanceof MessageSizeExceededError ? 1009 : 1007
+                  failWebsocketConnectionWithCode(this.ws, code, error.message)
                   return
                 }
 
-                this.writeFragments(data)
+                if (!this.writeFragments(data)) {
+                  return
+                }
 
                 if (this.#maxPayloadSize > 0 && this.#fragmentsBytes > this.#maxPayloadSize) {
-                  failWebsocketConnection(this.ws, new MessageSizeExceededError().message)
+                  failWebsocketConnectionWithCode(this.ws, 1009, new MessageSizeExceededError().message)
                   return
                 }
 
@@ -27372,8 +27620,17 @@ class ByteParser extends Writable {
   }
 
   writeFragments (fragment) {
+    if (
+      this.#maxFragments > 0 &&
+      this.#fragments.length === this.#maxFragments
+    ) {
+      failWebsocketConnectionWithCode(this.ws, 1008, 'Too many message fragments')
+      return false
+    }
+
     this.#fragmentsBytes += fragment.length
     this.#fragments.push(fragment)
+    return true
   }
 
   consumeFragments () {
@@ -28422,9 +28679,12 @@ class WebSocket extends EventTarget {
     // once this happens, the connection is open
     this[kResponse] = response
 
-    const maxPayloadSize = this[kController]?.dispatcher?.webSocketOptions?.maxPayloadSize
+    const webSocketOptions = this[kController]?.dispatcher?.webSocketOptions
+    const maxFragments = webSocketOptions?.maxFragments
+    const maxPayloadSize = webSocketOptions?.maxPayloadSize
 
     const parser = new ByteParser(this, parsedExtensions, {
+      maxFragments,
       maxPayloadSize
     })
     parser.on('drain', onParserDrain)
@@ -47107,6 +47367,15 @@ const BRANCH_PREFIX = 'chore/repo-hygiene/'
 const OWNER_PLACEHOLDER = '@OWNER'
 const KNOWN_BOTS = new Set(['dependabot', 'github-actions', 'renovate'])
 
+/**
+ * Slack renders the whole summary inside a single Block Kit `section`
+ * block, whose text is capped at 3000 characters, per
+ * https://docs.slack.dev/reference/block-kit/blocks/section-block
+ * About 400 of those go to the header `notify-status` composes around
+ * our text, which we cannot measure from here.
+ */
+const SLACK_MAX_CHARS = 2600
+
 // --- Helpers ---
 
 function normalisePattern(p) {
@@ -47243,6 +47512,46 @@ function clearScalarQuoting(node) {
       }
     },
   })
+}
+
+// The newline is included, so section costs add up to the length of the
+// joined text.
+function linesCost(lines) {
+  return lines.reduce((sum, line) => sum + line.length + 1, 0)
+}
+
+function renderList(heading, items) {
+  return ['', heading, ...items.map((item, idx) => `${idx + 1}. ${item}`)]
+}
+
+// One line standing in for a section we have no room to list.
+function countLabel({ heading, items }) {
+  return ['', `${heading} ${items.length} — see the run summary`]
+}
+
+/**
+ * As many of a section’s items as `budget` allows, ending in a note
+ * counting the rest. A section that does not fit at all — or one asked
+ * not to list `partial`ly, where half a list would be noise — collapses
+ * to its count label instead.
+ */
+function fillSection(section, budget, { partial }) {
+  const { heading, items } = section
+  const noteFor = (left) => `… and ${left} more`
+  let kept = []
+  for (const item of items) {
+    const next = [...kept, item]
+    const left = items.length - next.length
+    const lines = [
+      ...renderList(heading, next),
+      ...(left > 0 ? [noteFor(left)] : []),
+    ]
+    if (linesCost(lines) > budget) break
+    kept = next
+  }
+  if (kept.length === items.length) return renderList(heading, items)
+  if (!partial || kept.length === 0) return countLabel(section)
+  return [...renderList(heading, kept), noteFor(items.length - kept.length)]
 }
 
 // --- Main ---
@@ -47987,43 +48296,81 @@ async function main() {
       ? `reviewer(s): ${r.reviewers.join(', ')}`
       : 'no reviewer assigned'
 
-  const lines = []
-  if (opened.length > 0) {
-    lines.push(
-      '',
-      'Opened PRs:',
-      ...opened.map(
-        (r, idx) => `${idx + 1}. <${r.prUrl}> — ${reviewerSummary(r)}`
-      )
-    )
-  }
-  if (preexisting.length > 0) {
-    lines.push(
-      '',
-      'Pre-existing PRs:',
-      ...preexisting.map(
-        (r, idx) => `${idx + 1}. <${r.prUrl}> — ${reviewerSummary(r)}`
-      )
-    )
-  }
-  if (dryRuns.length > 0) {
-    lines.push(
-      '',
-      'Would open PRs (dry run):',
-      ...dryRuns.map(
-        (r, idx) => `${idx + 1}. ${r.repo} — ${reviewerSummary(r)}`
-      )
-    )
-  }
-  if (failed.length > 0) {
-    lines.push(
-      '',
-      'Failed repos:',
-      ...failed.map((r, idx) => `${idx + 1}. ${r.repo} — ${r.error}`)
-    )
+  const prItem = (r) => `<${r.prUrl}> — ${reviewerSummary(r)}`
+  const openedItems = opened.map(prItem)
+  const preexistingItems = preexisting.map(prItem)
+  const dryRunItems = dryRuns.map((r) => `${r.repo} — ${reviewerSummary(r)}`)
+  const failedItems = failed.map((r) => `${r.repo} — ${r.error}`)
+
+  const HEADINGS = {
+    opened: '*Opened PRs:*',
+    preexisting: '*Pre-existing PRs:*',
+    dryRun: '*Would open PRs (dry run):*',
+    failed: '*Failed repos:*',
   }
 
-  setOutput('slack_text', lines.join('\n'))
+  // The job summary lists everything.
+  const lines = [
+    ...(opened.length > 0 ? renderList(HEADINGS.opened, openedItems) : []),
+    ...(preexisting.length > 0
+      ? renderList(HEADINGS.preexisting, preexistingItems)
+      : []),
+    ...(dryRuns.length > 0 ? renderList(HEADINGS.dryRun, dryRunItems) : []),
+    ...(failed.length > 0 ? renderList(HEADINGS.failed, failedItems) : []),
+  ]
+
+  // Slack gets the same lists, fitted into one section block. Sections
+  // are filled in order of importance — failures, then opened, then
+  // pre-existing — and shown in a different order, with the failures
+  // first and the longest list last. Dry runs are left out: the workflow
+  // does not notify on a dry run.
+  const runUrl = [
+    process.env.GITHUB_SERVER_URL,
+    process.env.GITHUB_REPOSITORY,
+    'actions/runs',
+    process.env.GITHUB_RUN_ID,
+  ].join('/')
+  const footerLines = ['', `<${runUrl}|Full list in the run summary>`]
+  const slackSections = {
+    failed: { heading: HEADINGS.failed, items: failedItems },
+    opened: { heading: HEADINGS.opened, items: openedItems },
+    preexisting: { heading: HEADINGS.preexisting, items: preexistingItems },
+  }
+  const listed = Object.values(slackSections).filter(
+    ({ items }) => items.length > 0
+  )
+  // Reserve the footer and every section’s count label up front, so
+  // each section is guaranteed at least its count. A section gets its
+  // own reserve back when its turn comes; what the others leave unspent
+  // stays as a buffer.
+  let budget =
+    SLACK_MAX_CHARS -
+    linesCost(footerLines) -
+    listed.reduce((sum, section) => sum + linesCost(countLabel(section)), 0)
+  const filled = {}
+  for (const key of ['failed', 'opened', 'preexisting']) {
+    const section = slackSections[key]
+    if (section.items.length === 0) {
+      filled[key] = []
+    } else {
+      const reserve = linesCost(countLabel(section))
+      // A partial list of the least important PRs would be noise.
+      filled[key] = fillSection(section, budget + reserve, {
+        partial: key !== 'preexisting',
+      })
+      budget += reserve - linesCost(filled[key])
+    }
+  }
+
+  setOutput(
+    'slack_text',
+    [
+      ...filled.failed,
+      ...filled.preexisting,
+      ...filled.opened,
+      ...footerLines,
+    ].join('\n')
+  )
   setOutput(
     'should_notify',
     opened.length + failed.length > 0 ? 'true' : 'false'

--- a/repo-hygiene/index.mjs
+++ b/repo-hygiene/index.mjs
@@ -9,6 +9,15 @@ const BRANCH_PREFIX = 'chore/repo-hygiene/'
 const OWNER_PLACEHOLDER = '@OWNER'
 const KNOWN_BOTS = new Set(['dependabot', 'github-actions', 'renovate'])
 
+/**
+ * Slack renders the whole summary inside a single Block Kit `section`
+ * block, whose text is capped at 3000 characters, per
+ * https://docs.slack.dev/reference/block-kit/blocks/section-block
+ * About 400 of those go to the header `notify-status` composes around
+ * our text, which we cannot measure from here.
+ */
+const SLACK_MAX_CHARS = 2600
+
 // --- Helpers ---
 
 function normalisePattern(p) {
@@ -145,6 +154,46 @@ function clearScalarQuoting(node) {
       }
     },
   })
+}
+
+// The newline is included, so section costs add up to the length of the
+// joined text.
+function linesCost(lines) {
+  return lines.reduce((sum, line) => sum + line.length + 1, 0)
+}
+
+function renderList(heading, items) {
+  return ['', heading, ...items.map((item, idx) => `${idx + 1}. ${item}`)]
+}
+
+// One line standing in for a section we have no room to list.
+function countLabel({ heading, items }) {
+  return ['', `${heading} ${items.length} — see the run summary`]
+}
+
+/**
+ * As many of a section’s items as `budget` allows, ending in a note
+ * counting the rest. A section that does not fit at all — or one asked
+ * not to list `partial`ly, where half a list would be noise — collapses
+ * to its count label instead.
+ */
+function fillSection(section, budget, { partial }) {
+  const { heading, items } = section
+  const noteFor = (left) => `… and ${left} more`
+  let kept = []
+  for (const item of items) {
+    const next = [...kept, item]
+    const left = items.length - next.length
+    const lines = [
+      ...renderList(heading, next),
+      ...(left > 0 ? [noteFor(left)] : []),
+    ]
+    if (linesCost(lines) > budget) break
+    kept = next
+  }
+  if (kept.length === items.length) return renderList(heading, items)
+  if (!partial || kept.length === 0) return countLabel(section)
+  return [...renderList(heading, kept), noteFor(items.length - kept.length)]
 }
 
 // --- Main ---
@@ -889,43 +938,81 @@ async function main() {
       ? `reviewer(s): ${r.reviewers.join(', ')}`
       : 'no reviewer assigned'
 
-  const lines = []
-  if (opened.length > 0) {
-    lines.push(
-      '',
-      'Opened PRs:',
-      ...opened.map(
-        (r, idx) => `${idx + 1}. <${r.prUrl}> — ${reviewerSummary(r)}`
-      )
-    )
-  }
-  if (preexisting.length > 0) {
-    lines.push(
-      '',
-      'Pre-existing PRs:',
-      ...preexisting.map(
-        (r, idx) => `${idx + 1}. <${r.prUrl}> — ${reviewerSummary(r)}`
-      )
-    )
-  }
-  if (dryRuns.length > 0) {
-    lines.push(
-      '',
-      'Would open PRs (dry run):',
-      ...dryRuns.map(
-        (r, idx) => `${idx + 1}. ${r.repo} — ${reviewerSummary(r)}`
-      )
-    )
-  }
-  if (failed.length > 0) {
-    lines.push(
-      '',
-      'Failed repos:',
-      ...failed.map((r, idx) => `${idx + 1}. ${r.repo} — ${r.error}`)
-    )
+  const prItem = (r) => `<${r.prUrl}> — ${reviewerSummary(r)}`
+  const openedItems = opened.map(prItem)
+  const preexistingItems = preexisting.map(prItem)
+  const dryRunItems = dryRuns.map((r) => `${r.repo} — ${reviewerSummary(r)}`)
+  const failedItems = failed.map((r) => `${r.repo} — ${r.error}`)
+
+  const HEADINGS = {
+    opened: '*Opened PRs:*',
+    preexisting: '*Pre-existing PRs:*',
+    dryRun: '*Would open PRs (dry run):*',
+    failed: '*Failed repos:*',
   }
 
-  core.setOutput('slack_text', lines.join('\n'))
+  // The job summary lists everything.
+  const lines = [
+    ...(opened.length > 0 ? renderList(HEADINGS.opened, openedItems) : []),
+    ...(preexisting.length > 0
+      ? renderList(HEADINGS.preexisting, preexistingItems)
+      : []),
+    ...(dryRuns.length > 0 ? renderList(HEADINGS.dryRun, dryRunItems) : []),
+    ...(failed.length > 0 ? renderList(HEADINGS.failed, failedItems) : []),
+  ]
+
+  // Slack gets the same lists, fitted into one section block. Sections
+  // are filled in order of importance — failures, then opened, then
+  // pre-existing — and shown in a different order, with the failures
+  // first and the longest list last. Dry runs are left out: the workflow
+  // does not notify on a dry run.
+  const runUrl = [
+    process.env.GITHUB_SERVER_URL,
+    process.env.GITHUB_REPOSITORY,
+    'actions/runs',
+    process.env.GITHUB_RUN_ID,
+  ].join('/')
+  const footerLines = ['', `<${runUrl}|Full list in the run summary>`]
+  const slackSections = {
+    failed: { heading: HEADINGS.failed, items: failedItems },
+    opened: { heading: HEADINGS.opened, items: openedItems },
+    preexisting: { heading: HEADINGS.preexisting, items: preexistingItems },
+  }
+  const listed = Object.values(slackSections).filter(
+    ({ items }) => items.length > 0
+  )
+  // Reserve the footer and every section’s count label up front, so
+  // each section is guaranteed at least its count. A section gets its
+  // own reserve back when its turn comes; what the others leave unspent
+  // stays as a buffer.
+  let budget =
+    SLACK_MAX_CHARS -
+    linesCost(footerLines) -
+    listed.reduce((sum, section) => sum + linesCost(countLabel(section)), 0)
+  const filled = {}
+  for (const key of ['failed', 'opened', 'preexisting']) {
+    const section = slackSections[key]
+    if (section.items.length === 0) {
+      filled[key] = []
+    } else {
+      const reserve = linesCost(countLabel(section))
+      // A partial list of the least important PRs would be noise.
+      filled[key] = fillSection(section, budget + reserve, {
+        partial: key !== 'preexisting',
+      })
+      budget += reserve - linesCost(filled[key])
+    }
+  }
+
+  core.setOutput(
+    'slack_text',
+    [
+      ...filled.failed,
+      ...filled.preexisting,
+      ...filled.opened,
+      ...footerLines,
+    ].join('\n')
+  )
   core.setOutput(
     'should_notify',
     opened.length + failed.length > 0 ? 'true' : 'false'


### PR DESCRIPTION
## Why?

`repo-hygiene` posts its run summary through `notify-status`, which puts the whole text into a single Block Kit `section` block. That block’s `text` is capped at 3000 characters — the widely quoted 40 000 applies to a message’s top-level `text` field, not to blocks. The summary lists every opened and every pre-existing PR, so an org-wide run overflows the cap, Slack rejects the post with `invalid_blocks`, the step fails, and no notification arrives at all — precisely when one was wanted.

## What?

`repo-hygiene` now fits `slack_text` to a character budget (2600 — the 3000 limit less roughly 400 for the header `notify-status` composes around it, which the action cannot measure). There is no cap on the number of listed PRs; characters alone decide.

- The footer link to the run summary, plus one count label per section, are deducted from the budget up front, so **every section keeps at least its count** no matter how long the sections ahead of it are. Unspent reserves carry forward as a buffer.
- Sections are filled in order of importance — failures, opened, pre-existing — and shown in a different order: failures, pre-existing, opened.
- A section that does not fit lists as many items as it can and ends in `… and N more`. Pre-existing PRs are the exception: all-or-count, since half a list of the least important entries is noise.
- Slack headings are bold now. `core.summary` keeps plain headings, because `*…*` is _italic_ in Markdown, and keeps the full untrimmed list — which is what the footer link points at. `results_json` is unchanged.

`notify-status` gains a dumb backstop of its own: it knows the whole text, so its Compose-message step truncates anything over 2900 characters back to a line boundary (never severing a `<url|label>` link), appends `… (truncated)` and emits a warning. Every other caller gets the same protection.

Design notes live in [`docs/superpowers/specs/2026-08-06-repo-hygiene-slack-truncation-design.md`](docs/superpowers/specs/2026-08-06-repo-hygiene-slack-truncation-design.md).

The rebuilt `dist/` also picks up the vendored dependency updates that landed in the lockfile since it was last built, which inflates its diff.

Example of a fitted message, with 2 failures, 9 pre-existing and 40 opened PRs (elisions marked):

```
<!here> *🔴 FAILED* Repo hygiene: verkstedt/repo-hygiene-runner @ main


*Failed repos:*
1. verkstedt/billing-hooks — protected branch update failed: 403
2. verkstedt/locale-extractor — repository is archived

*Pre-existing PRs:* 9 — see the run summary

*Opened PRs:*
1. <https://github.com/verkstedt/tim-terminbot/pull/100> — reviewer(s): @verkstedt/devs
(…)
25. <https://github.com/verkstedt/mail-templates/pull/172> — reviewer(s): @verkstedt/devs
… and 15 more

<https://github.com/verkstedt/repo-hygiene-runner/actions/runs/16987654321|Full list in the run summary>
```

@coderabbitai ignore

---

```
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
```
